### PR TITLE
Move 'to_http_status_code(StorageError)' to the SDK library

### DIFF
--- a/edjstorage-delete/src/serverless_function.cpp
+++ b/edjstorage-delete/src/serverless_function.cpp
@@ -20,28 +20,6 @@ using edjx::http::HttpStatusCode;
 static const HttpStatusCode HTTP_STATUS_OK = 200;
 static const HttpStatusCode HTTP_STATUS_BAD_REQUEST = 400;
 
-HttpStatusCode to_http_status_code(StorageError e) {
-    switch (e) {
-        case StorageError::Success:
-            return 200;
-        case StorageError::EmptyContent:
-        case StorageError::MissingFileName:
-        case StorageError::MissingBucketID:
-        case StorageError::MissingAttributes:
-        case StorageError::InvalidAttributes:
-            return 400; //HTTP_STATUS_BAD_REQUEST;
-        case StorageError::ContentNotFound:
-        case StorageError::ContentDeleted:
-            return 404; //HTTP_STATUS_NOT_FOUND;
-        case StorageError::UnAuthorized:
-            return 403; //HTTP_STATUS_FORBIDDEN;
-        case StorageError::DeletedBucketID:
-        case StorageError::InternalError:
-        case StorageError::SystemError:
-            return 500; //HTTP_STATUS_INTERNAL_SERVER_ERROR;
-    }
-}
-
 std::optional<std::string> query_param_by_name(const HttpRequest & req, const std::string & param_name) {
     std::string uri = req.get_uri().as_string();
     std::vector<std::pair<std::string, std::string>> query_parsed;
@@ -116,7 +94,7 @@ HttpResponse serverless(const HttpRequest & req) {
     if (err != StorageError::Success) {
         error("Content Deletion Failed");
         return HttpResponse(to_string(err))
-            .set_status(to_http_status_code(err));
+            .set_status(edjx::error::to_http_status_code(err));
     };
 
     HttpResponse res = HttpResponse("Success").set_status(HTTP_STATUS_OK);

--- a/edjstorage-get-attributes/src/serverless_function.cpp
+++ b/edjstorage-get-attributes/src/serverless_function.cpp
@@ -21,28 +21,6 @@ using edjx::http::HttpStatusCode;
 static const HttpStatusCode HTTP_STATUS_OK = 200;
 static const HttpStatusCode HTTP_STATUS_BAD_REQUEST = 400;
 
-HttpStatusCode to_http_status_code(StorageError e) {
-    switch (e) {
-        case StorageError::Success:
-            return 200;
-        case StorageError::EmptyContent:
-        case StorageError::MissingFileName:
-        case StorageError::MissingBucketID:
-        case StorageError::MissingAttributes:
-        case StorageError::InvalidAttributes:
-            return 400; //HTTP_STATUS_BAD_REQUEST;
-        case StorageError::ContentNotFound:
-        case StorageError::ContentDeleted:
-            return 404; //HTTP_STATUS_NOT_FOUND;
-        case StorageError::UnAuthorized:
-            return 403; //HTTP_STATUS_FORBIDDEN;
-        case StorageError::DeletedBucketID:
-        case StorageError::InternalError:
-        case StorageError::SystemError:
-            return 500; //HTTP_STATUS_INTERNAL_SERVER_ERROR;
-    }
-}
-
 std::optional<std::string> query_param_by_name(const HttpRequest & req, const std::string & param_name) {
     std::string uri = req.get_uri().as_string();
     std::vector<std::pair<std::string, std::string>> query_parsed;
@@ -194,7 +172,7 @@ HttpResponse serverless(const HttpRequest & req) {
     StorageError err = get_attributes(res_bytes, bucket_id.value(), file_name.value());
     if (err != StorageError::Success) {
         return HttpResponse(to_string(err))
-            .set_status(to_http_status_code(err));
+            .set_status(edjx::error::to_http_status_code(err));
     };
 
     std::string attr_res = to_json(res_bytes);

--- a/edjstorage-get-with-http/src/serverless_function.cpp
+++ b/edjstorage-get-with-http/src/serverless_function.cpp
@@ -22,28 +22,6 @@ using edjx::http::HttpStatusCode;
 static const HttpStatusCode HTTP_STATUS_OK = 200;
 static const HttpStatusCode HTTP_STATUS_BAD_REQUEST = 400;
 
-HttpStatusCode to_http_status_code(StorageError e) {
-    switch (e) {
-        case StorageError::Success:
-            return 200;
-        case StorageError::EmptyContent:
-        case StorageError::MissingFileName:
-        case StorageError::MissingBucketID:
-        case StorageError::MissingAttributes:
-        case StorageError::InvalidAttributes:
-            return 400; //HTTP_STATUS_BAD_REQUEST;
-        case StorageError::ContentNotFound:
-        case StorageError::ContentDeleted:
-            return 404; //HTTP_STATUS_NOT_FOUND;
-        case StorageError::UnAuthorized:
-            return 403; //HTTP_STATUS_FORBIDDEN;
-        case StorageError::DeletedBucketID:
-        case StorageError::InternalError:
-        case StorageError::SystemError:
-            return 500; //HTTP_STATUS_INTERNAL_SERVER_ERROR;
-    }
-}
-
 std::optional<std::string> query_param_by_name(const HttpRequest & req, const std::string & param_name) {
     std::string uri = req.get_uri().as_string();
     std::vector<std::pair<std::string, std::string>> query_parsed;
@@ -116,7 +94,7 @@ HttpResponse serverless(const HttpRequest & req) {
     StorageResponse res_bytes;
     StorageError err = edjx::storage::get(res_bytes, bucket_id.value(), file_name.value());
     if (err != StorageError::Success) {
-        return HttpResponse(to_string(err)).set_status(to_http_status_code(err));
+        return HttpResponse(to_string(err)).set_status(edjx::error::to_http_status_code(err));
     }
     info("Get Content Successful");
 

--- a/edjstorage-put-with-http/src/serverless_function.cpp
+++ b/edjstorage-put-with-http/src/serverless_function.cpp
@@ -22,28 +22,6 @@ using edjx::http::HttpStatusCode;
 static const HttpStatusCode HTTP_STATUS_OK = 200;
 static const HttpStatusCode HTTP_STATUS_BAD_REQUEST = 400;
 
-HttpStatusCode to_http_status_code(StorageError e) {
-    switch (e) {
-        case StorageError::Success:
-            return 200;
-        case StorageError::EmptyContent:
-        case StorageError::MissingFileName:
-        case StorageError::MissingBucketID:
-        case StorageError::MissingAttributes:
-        case StorageError::InvalidAttributes:
-            return 400; //HTTP_STATUS_BAD_REQUEST;
-        case StorageError::ContentNotFound:
-        case StorageError::ContentDeleted:
-            return 404; //HTTP_STATUS_NOT_FOUND;
-        case StorageError::UnAuthorized:
-            return 403; //HTTP_STATUS_FORBIDDEN;
-        case StorageError::DeletedBucketID:
-        case StorageError::InternalError:
-        case StorageError::SystemError:
-            return 500; //HTTP_STATUS_INTERNAL_SERVER_ERROR;
-    }
-}
-
 std::optional<std::string> query_param_by_name(const HttpRequest & req, const std::string & param_name) {
     std::string uri = req.get_uri().as_string();
     std::vector<std::pair<std::string, std::string>> query_parsed;
@@ -122,7 +100,7 @@ HttpResponse serverless(const HttpRequest & req) {
     StorageResponse put_res;
     StorageError err = edjx::storage::put(put_res, bucket_id.value(), file_name.value(), properties.value_or(""), buf_data);
     if (err != StorageError::Success) {
-        return HttpResponse(to_string(err)).set_status(to_http_status_code(err));
+        return HttpResponse(to_string(err)).set_status(edjx::error::to_http_status_code(err));
     }
     info("Put Content Successful");
 

--- a/edjstorage-set-attributes/src/serverless_function.cpp
+++ b/edjstorage-set-attributes/src/serverless_function.cpp
@@ -22,28 +22,6 @@ using edjx::http::HttpStatusCode;
 static const HttpStatusCode HTTP_STATUS_OK = 200;
 static const HttpStatusCode HTTP_STATUS_BAD_REQUEST = 400;
 
-HttpStatusCode to_http_status_code(StorageError e) {
-    switch (e) {
-        case StorageError::Success:
-            return 200;
-        case StorageError::EmptyContent:
-        case StorageError::MissingFileName:
-        case StorageError::MissingBucketID:
-        case StorageError::MissingAttributes:
-        case StorageError::InvalidAttributes:
-            return 400; //HTTP_STATUS_BAD_REQUEST;
-        case StorageError::ContentNotFound:
-        case StorageError::ContentDeleted:
-            return 404; //HTTP_STATUS_NOT_FOUND;
-        case StorageError::UnAuthorized:
-            return 403; //HTTP_STATUS_FORBIDDEN;
-        case StorageError::DeletedBucketID:
-        case StorageError::InternalError:
-        case StorageError::SystemError:
-            return 500; //HTTP_STATUS_INTERNAL_SERVER_ERROR;
-    }
-}
-
 std::optional<std::string> query_param_by_name(const HttpRequest & req, const std::string & param_name) {
     std::string uri = req.get_uri().as_string();
     std::vector<std::pair<std::string, std::string>> query_parsed;
@@ -126,7 +104,7 @@ HttpResponse serverless(const HttpRequest & req) {
     StorageError err = edjx::storage::set_attributes(put_res, bucket_id.value(), file_name.value(), new_attributes);
     if (err != StorageError::Success) {
         return HttpResponse(to_string(err))
-            .set_status(to_http_status_code(err));
+            .set_status(edjx::error::to_http_status_code(err));
     }
 
     info("Set Attributes Successful");


### PR DESCRIPTION
Move the `to_http_status_code(StorageError)` function to the SDK library, remove its implementation from example application code.

Merge after the updated SDK library is released.